### PR TITLE
Test harness part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+0.0.2
+=====
+
+- Swindler.state has been replaced with Swindler.initialize(), which returns a
+  Promise.
+- An experimental FakeSwindler API has been added for testing code which depends
+  on Swindler. The API is expected to change, but probably not too much.
+- Setting the frontmostApplication from Swindler should now work.
+- Various bug fixes and improvements.

--- a/Sources/AXPropertyDelegate.swift
+++ b/Sources/AXPropertyDelegate.swift
@@ -123,9 +123,7 @@ func fetchAttributes<UIElement: UIElementType>(_ attributeNames: [Attribute],
 
 /// Returns a promise that resolves when all the provided properties are initialized.
 /// Adds additional error information for AXPropertyDelegates.
-func initializeProperties<UIElement: UIElementType>(_ properties: [PropertyType],
-                                                    ofElement axElement: UIElement)
--> Promise<Void> {
+func initializeProperties(_ properties: [PropertyType]) -> Promise<Void> {
     let propertiesInitialized: [Promise<Void>] = Array(properties.map({ $0.initialized }))
     return when(fulfilled: propertiesInitialized)
 }

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -60,6 +60,12 @@ public func ==(lhs: Application, rhs: Application) -> Bool {
 }
 extension Application: Equatable {}
 
+extension Application: CustomStringConvertible {
+    public var description: String {
+        return "Application(\(String(describing: delegate)))"
+    }
+}
+
 protocol ApplicationDelegate: class {
     var processIdentifier: pid_t! { get }
     var bundleIdentifier: String? { get }
@@ -461,10 +467,12 @@ extension OSXApplicationDelegate: PropertyNotifier {
 extension OSXApplicationDelegate: CustomStringConvertible {
     var description: String {
         do {
-            guard let app = NSRunningApplication(processIdentifier: try self.axElement.pid()) else {
-                return "Unknown"
+            let pid = try self.axElement.pid()
+            if let app = NSRunningApplication(processIdentifier: pid),
+               let bundle = app.bundleIdentifier {
+                return bundle
             }
-            return app.bundleIdentifier ?? "Unknown"
+            return "pid=\(pid)"
         } catch {
             return "Invalid"
         }

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -135,8 +135,8 @@ final class OSXApplicationDelegate<
     }
 
     init(axElement: ApplicationElement,
-                     stateDelegate: StateDelegate,
-                     notifier: EventNotifier) throws {
+         stateDelegate: StateDelegate,
+         notifier: EventNotifier) throws {
         // TODO: filter out applications by activation policy
         self.axElement = axElement.toElement
         self.stateDelegate = stateDelegate
@@ -205,7 +205,7 @@ final class OSXApplicationDelegate<
                         fulfill: fulfillAttrs,
                         reject: rejectAttrs)
 
-        initialized = initializeProperties(properties, ofElement: axElement).asVoid()
+        initialized = initializeProperties(properties).asVoid()
     }
 
     /// Called during initialization to set up an observer on the application element.

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -86,6 +86,13 @@ class TestApplicationElementBase: TestUIElement {
         }
 
         try super.setAttribute(attribute, value: value)
+
+        // Propagate .mainWindow changes to .focusedWindow also.
+        // This is what happens 99% of the time, but it is still possible to set
+        // .focusedWindow only.
+        if attribute == .mainWindow {
+            try self.setAttribute(.focusedWindow, value: value)
+        }
     }
 
     internal var windows: [TestUIElement] {

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -16,7 +16,7 @@ fileprivate typealias AppElement = EmittingTestApplicationElement
 
 public class FakeState {
     fileprivate typealias Delegate =
-        OSXStateDelegate<TestUIElement, AppElement, FakeObserver>;
+        OSXStateDelegate<TestUIElement, AppElement, FakeObserver>
 
     public var state: State
 
@@ -29,9 +29,11 @@ public class FakeState {
     fileprivate var delegate: Delegate
     var appObserver: FakeApplicationObserver
 
-    public init() {
+    public init(screens: [FakeScreen] = [FakeScreen()]) {
+        let screens = FakeSystemScreenDelegate(screens: screens.map{ $0.delegate })
+
         appObserver = FakeApplicationObserver()
-        delegate = Delegate(appObserver: appObserver)
+        delegate = Delegate(appObserver: appObserver, screens: screens)
         state = State(delegate: delegate)
     }
 }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -23,6 +23,11 @@ public func ==(lhs: Screen, rhs: Screen) -> Bool {
     return lhs.delegate.equalTo(rhs.delegate)
 }
 
+protocol SystemScreenDelegate {
+    associatedtype Delegate: ScreenDelegate
+    func createForAll() -> [Delegate]
+}
+
 protocol ScreenDelegate: class, CustomDebugStringConvertible {
     var frame: CGRect { get }
     var applicationFrame: CGRect { get }
@@ -30,7 +35,15 @@ protocol ScreenDelegate: class, CustomDebugStringConvertible {
     func equalTo(_ other: ScreenDelegate) -> Bool
 }
 
-class FakeScreenDelegate: ScreenDelegate {
+struct FakeSystemScreenDelegate: SystemScreenDelegate {
+    typealias Delegate = FakeScreenDelegate
+    var screens: [Delegate]
+    func createForAll() -> [Delegate] {
+        return screens
+    }
+}
+
+final class FakeScreenDelegate: ScreenDelegate {
     let frame: CGRect
     let applicationFrame: CGRect
 
@@ -68,6 +81,13 @@ extension NSScreen: NSScreenType {
             return "Unnamed screen"
         }
         return name
+    }
+}
+
+struct OSXSystemScreenDelegate: SystemScreenDelegate {
+    typealias ScreenDelegate = OSXScreenDelegate<NSScreen>
+    func createForAll() -> [ScreenDelegate] {
+        return NSScreen.screens.map{ OSXScreenDelegate(nsScreen: $0) }
     }
 }
 

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -4,7 +4,8 @@ import PromiseKit
 /// The global Swindler state, lazily initialized.
 public var state = State(
     delegate: OSXStateDelegate<AXSwift.UIElement, AXSwift.Application, AXSwift.Observer>(
-        appObserver: ApplicationObserver()
+        appObserver: ApplicationObserver(),
+        screens: OSXSystemScreenDelegate()
     )
 )
 
@@ -195,9 +196,9 @@ final class OSXStateDelegate<
     // TODO: retry instead of ignoring an app/window when timeouts are encountered during
     // initialization?
 
-    init(appObserver: ApplicationObserverType) {
+    init<S: SystemScreenDelegate>(appObserver: ApplicationObserverType, screens: S) {
         log.debug("Initializing Swindler")
-        screens = NSScreen.screens.map { OSXScreenDelegate(nsScreen: $0) }
+        self.screens = screens.createForAll().map{ $0 as ScreenDelegate }
 
         //    screenObserver.onScreenLayoutChanged {
         //      let (screens, event) = OSXScreenDelegate<NSScreen>.handleScreenChange(

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -138,9 +138,15 @@ struct ApplicationObserver: ApplicationObserverType {
 
     func makeApplicationFrontmost(_ pid: pid_t) throws {
         guard let app = NSRunningApplication(processIdentifier: pid) else {
+            log.info("Could not find requested application to make frontmost with pid \(pid)")
             throw OSXDriverError.runningApplicationNotFound(processID: pid)
         }
-        app.activate(options: [])
+        let success = try traceRequest(app, "activate", "") {
+            app.activate(options: [NSApplication.ActivationOptions.activateIgnoringOtherApps])
+        }
+        if !success {
+            log.debug("Failed to activate application \(app), it probably quit")
+        }
     }
 }
 

--- a/Sources/Window.swift
+++ b/Sources/Window.swift
@@ -218,9 +218,7 @@ final class OSXWindowDelegate<
             }
         }
 
-        initialized =
-            when(fulfilled: initializeProperties(axProperties, ofElement: axElement).asVoid(),
-                 subroleChecked)
+        initialized = when(fulfilled: initializeProperties(axProperties).asVoid(), subroleChecked)
     }
 
     private func watchWindowElement(_ element: UIElement,

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -25,9 +25,10 @@ class OSXDriverSpec: QuickSpec {
             appElement.attrs[.mainWindow] = windowElement
             TestApplicationElement.allApps = [appElement]
 
+            let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
             state = State(delegate: OSXStateDelegate<
                 TestUIElement, TestApplicationElement, FakeObserver
-            >(appObserver: StubApplicationObserver()))
+            >(appObserver: StubApplicationObserver(), screens: screenDel))
             observer = FakeObserver.observers.first!
             observer.emit(.windowCreated, forElement: windowElement)
             expect(state.knownWindows.count).toEventually(equal(1))

--- a/SwindlerTests/StateSpec.swift
+++ b/SwindlerTests/StateSpec.swift
@@ -57,9 +57,10 @@ class OSXStateDelegateSpec: QuickSpec {
         func initialize(
             _ appObserver: ApplicationObserverType = StubApplicationObserver()
         ) -> OSXStateDelegate<TestUIElement, TestApplicationElement, TestObserver> {
+            let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
             let stateDel = OSXStateDelegate<
                 TestUIElement, TestApplicationElement, TestObserver
-            >(appObserver: appObserver)
+            >(appObserver: appObserver, screens: screenDel)
             waitUntil { done in
                 stateDel.frontmostApplication.initialized.then { done() }.always {}
             }
@@ -81,8 +82,10 @@ class OSXStateDelegateSpec: QuickSpec {
         context("during initialization") {
             func initializeUsingObserver<Obs: ObserverType>(_ elementObserver: Obs.Type)
                 -> OSXStateDelegate<TestUIElement, TestApplicationElement, Obs> {
+                let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
                 return OSXStateDelegate<TestUIElement, TestApplicationElement, Obs>(
-                    appObserver: StubApplicationObserver()
+                    appObserver: StubApplicationObserver(),
+                    screens: screenDel
                 )
             }
 


### PR DESCRIPTION
Flesh out functionality in `FakeState`. Also fixes some bugs in Swindler itself.

Replace lazy var state with initialize(): this corrects a bug in the interface.