### PR TITLE
When written value != desired, mark event external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Breaking changes
   at bottom-left), to match the behavior of Screen and most modern macOS APIs.
 - `Window.position` was made non-writeable (use `Window.frame` instead). It may
   be removed in the future. See #29 for more.
+- When a property value is written to, and the new value is changed but does
+  not match the desired value, the corresponding event is marked as external.
+  See #49.
 
 New features
 - A `Window.frame` property was added. You can now atomically change the whole

--- a/SwindlerTests/PropertySpec.swift
+++ b/SwindlerTests/PropertySpec.swift
@@ -447,10 +447,10 @@ class PropertySpec: QuickSpec {
                         }
                     }
 
-                    it("marks the event as internal") {
+                    it("marks the event as external") {
                         return property.set(secondPoint).then { _ -> Void in
                             if let event = notifier.events.first {
-                                expect(event.external).to(beFalse())
+                                expect(event.external).to(beTrue())
                             }
                         }
                     }


### PR DESCRIPTION
This seems more conservative. Closes #49; see that issue for more.