### PR TITLE
WindowFrameChangedEvent

### DIFF
--- a/API.swift
+++ b/API.swift
@@ -147,11 +147,12 @@ public protocol Window: Equatable {
 // WindowCreatedEvent
 // WindowDestroyedEvent
 // WindowDiscoveredEvent
+// WindowFrameChangedEvent
+// WindowMinimizedChangedEvent
+// WindowTitleChangedEvent
 //
 // PositionChanged
 // SizeChanged
-// TitleChanged
-// IsMinimizedChanged
 // IsFullScreenChanged (?)
 // ScreenChanged
 //   - cause: {.Moved, .ScreenLayoutChanged}

--- a/API.swift
+++ b/API.swift
@@ -146,13 +146,11 @@ public protocol Window: Equatable {
 
 // WindowCreatedEvent
 // WindowDestroyedEvent
-// WindowDiscoveredEvent
 // WindowFrameChangedEvent
 // WindowMinimizedChangedEvent
 // WindowTitleChangedEvent
 //
-// PositionChanged
-// SizeChanged
+// WindowDiscoveredEvent
 // IsFullScreenChanged (?)
 // ScreenChanged
 //   - cause: {.Moved, .ScreenLayoutChanged}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ Breaking changes
   at bottom-left), to match the behavior of Screen and most modern macOS APIs.
 - `Window.position` was made non-writeable (use `Window.frame` instead). It may
   be removed in the future. See #29 for more.
-- When a property value is written to, and the new value is changed but does
-  not match the desired value, the corresponding event is marked as external.
-  See #49.
+- `WindowFrameChangedEvent` was added, replacing `WindowPosChangedEvent` and
+  `WindowSizeChangedEvent`. See #16 for more.
 
 New features
 - A `Window.frame` property was added. You can now atomically change the whole
@@ -16,6 +15,9 @@ New features
 
 Bug fixes
 - `ScreenLayoutChangedEvent` is now correctly detected.
+- When a property value is written to, and the new value is changed but does
+  not match the desired value, the corresponding event is marked as external.
+  See #49.
 
 0.0.2
 =====

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -77,7 +77,7 @@ extension WindowPropertyEventType {
     }
 }
 
-struct WindowFrameChangedEvent: WindowPropertyEventType {
+public struct WindowFrameChangedEvent: WindowPropertyEventType {
     public typealias PropertyType = CGRect
     public let external: Bool
     public let window: Window

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -85,22 +85,6 @@ public struct WindowFrameChangedEvent: WindowPropertyEventType {
     public let newValue: PropertyType
 }
 
-public struct WindowPosChangedEvent: WindowPropertyEventType {
-    public typealias PropertyType = CGPoint
-    public let external: Bool
-    public let window: Window
-    public let oldValue: PropertyType
-    public let newValue: PropertyType
-}
-
-public struct WindowSizeChangedEvent: WindowPropertyEventType {
-    public typealias PropertyType = CGSize
-    public let external: Bool
-    public let window: Window
-    public let oldValue: PropertyType
-    public let newValue: PropertyType
-}
-
 public struct WindowTitleChangedEvent: WindowPropertyEventType {
     public typealias PropertyType = String
     public let external: Bool

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -222,8 +222,6 @@ final class OSXStateDelegate<
             self.notifier.notify(event)
         }
 
-        WinDelegate.onStateInit(notifier)
-
         let appPromises = ApplicationElement.all().map { appElement in
             watchApplication(appElement: appElement)
             .asVoid()

--- a/Sources/Window.swift
+++ b/Sources/Window.swift
@@ -265,31 +265,6 @@ final class OSXWindowDelegate<
     }
 }
 
-extension OSXWindowDelegate {
-    static func onStateInit(_ notifier: EventNotifier) {
-        // Translate from WindowFrameChangedEvent to WindowPosChangedEvent and
-        // WindowSizeChangedEvent.
-        notifier.on() { (event: WindowFrameChangedEvent) in
-            if event.oldValue.origin != event.newValue.origin {
-                notifier.notify(WindowPosChangedEvent(
-                    external: event.external,
-                    window: event.window,
-                    oldValue: event.oldValue.origin,
-                    newValue: event.newValue.origin
-                ))
-            }
-            if event.oldValue.size != event.newValue.size {
-                notifier.notify(WindowSizeChangedEvent(
-                    external: event.external,
-                    window: event.window,
-                    oldValue: event.oldValue.size,
-                    newValue: event.newValue.size
-                ))
-            }
-        }
-    }
-}
-
 /// Interface used by OSXApplicationDelegate.
 extension OSXWindowDelegate {
     /// Initializes the window, and returns it in a Promise once it's ready.

--- a/SwindlerExample/AppDelegate.swift
+++ b/SwindlerExample/AppDelegate.swift
@@ -54,12 +54,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let window = event.window
             print("new window: \(window.title.value)")
         }
-        swindler.on { (event: WindowPosChangedEvent) in
-            print("Pos changed from \(event.oldValue) to \(event.newValue),",
-                  "external: \(event.external)")
-        }
-        swindler.on { (event: WindowSizeChangedEvent) in
-            print("Size changed from \(event.oldValue) to \(event.newValue),",
+        swindler.on { (event: WindowFrameChangedEvent) in
+            print("Frame changed from \(event.oldValue) to \(event.newValue),",
                   "external: \(event.external)")
         }
         swindler.on { (event: WindowDestroyedEvent) in

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -85,7 +85,7 @@ class OSXDriverSpec: QuickSpec {
 
             it("emits a ChangedEvent") {
                 var callbacks = 0
-                state.on { (_: WindowPosChangedEvent) in
+                state.on { (_: WindowFrameChangedEvent) in
                     callbacks += 1
                 }
                 windowElement.attrs[.position] = CGPoint(x: 100, y: 100)
@@ -97,10 +97,10 @@ class OSXDriverSpec: QuickSpec {
             it("calls multiple event handlers") {
                 var callbacks1 = 0
                 var callbacks2 = 0
-                state.on { (_: WindowPosChangedEvent) in
+                state.on { (_: WindowFrameChangedEvent) in
                     callbacks1 += 1
                 }
-                state.on { (_: WindowPosChangedEvent) in
+                state.on { (_: WindowFrameChangedEvent) in
                     callbacks2 += 1
                 }
                 windowElement.attrs[.position] = CGPoint(x: 100, y: 100)

--- a/SwindlerTests/WindowSpec.swift
+++ b/SwindlerTests/WindowSpec.swift
@@ -241,7 +241,6 @@ class OSXWindowDelegateSpec: QuickSpec {
             windowElement.attrs[.title]    = "a window"
 
             notifier = TestNotifier()
-            WinDelegate.onStateInit(notifier)
             waitUntil { done in
                 let screen = FakeScreen(frame: CGRect(x: 0, y: 0, width: 1000, height: 1000))
                 let systemScreens = FakeSystemScreenDelegate(screens: [screen.delegate])

--- a/SwindlerTests/WindowSpec.swift
+++ b/SwindlerTests/WindowSpec.swift
@@ -275,14 +275,14 @@ class OSXWindowDelegateSpec: QuickSpec {
                 windowDelegate.handleEvent(.moved, observer: TestObserver())
             }
 
-            it("emits a WindowPosChangedEvent") {
-                if let event = notifier.expectEvent(WindowPosChangedEvent.self) {
+            it("emits a WindowFrameChangedEvent") {
+                if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
                     expect(getWindowElement(event.window)).to(equal(windowElement))
                 }
             }
 
             it("marks the event as external") {
-                if let event = notifier.waitUntilEvent(WindowPosChangedEvent.self) {
+                if let event = notifier.waitUntilEvent(WindowFrameChangedEvent.self) {
                     expect(event.external).to(beTrue())
                 }
             }
@@ -303,8 +303,8 @@ class OSXWindowDelegateSpec: QuickSpec {
                     setFrame(CGRect(x: 500, y: 500, width: 100, height: 100),
                              inverted: CGPoint(x: 500, y: 400))
                 }
-                it("emits an internal WindowPosChangedEvent") {
-                    if let event = notifier.expectEvent(WindowPosChangedEvent.self) {
+                it("emits an internal WindowFrameChangedEvent") {
+                    if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
                         expect(getWindowElement(event.window)).to(equal(windowElement))
                         expect(event.external).to(beFalse())
                     }
@@ -316,8 +316,8 @@ class OSXWindowDelegateSpec: QuickSpec {
                     setFrame(CGRect(x: 0, y: 800, width: 200, height: 200),
                              inverted: CGPoint(x: 0, y: 0))
                 }
-                it("emits an internal WindowSizeChangedEvent") {
-                    if let event = notifier.expectEvent(WindowSizeChangedEvent.self) {
+                it("emits an internal WindowFrameChangedEvent") {
+                    if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
                         expect(getWindowElement(event.window)).to(equal(windowElement))
                         expect(event.external).to(beFalse())
                     }
@@ -329,14 +329,8 @@ class OSXWindowDelegateSpec: QuickSpec {
                     setFrame(CGRect(x: 500, y: 500, width: 200, height: 200),
                              inverted: CGPoint(x: 500, y: 300))
                 }
-                it("emits an internal WindowPosChangedEvent") {
-                    if let event = notifier.expectEvent(WindowPosChangedEvent.self) {
-                        expect(getWindowElement(event.window)).to(equal(windowElement))
-                        expect(event.external).to(beFalse())
-                    }
-                }
-                it("emits an internal WindowSizeChangedEvent") {
-                    if let event = notifier.expectEvent(WindowSizeChangedEvent.self) {
+                it("emits an internal WindowFrameChangedEvent") {
+                    if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
                         expect(getWindowElement(event.window)).to(equal(windowElement))
                         expect(event.external).to(beFalse())
                     }


### PR DESCRIPTION
Adds `WindowFrameChangedEvent`, replacing both `WindowPosChangedEvent` and `WindowSizeChangedEvent`.

Finally closes #16.