### PR TITLE
Sync `size` with `frame`

### DIFF
--- a/Sources/AXPropertyDelegate.swift
+++ b/Sources/AXPropertyDelegate.swift
@@ -101,7 +101,7 @@ extension AXPropertyDelegate: AXPropertyDelegateType {}
 protocol PropertyType {
     func issueRefresh()
     var delegate: Any { get }
-    var initialized: Promise<Void> { get }
+    var initialized: Promise<Void>! { get }
 }
 extension Property: PropertyType {
     func issueRefresh() {

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -150,10 +150,10 @@ public class FakeWindowBuilder {
     }
 
     public func setTitle(_ title: String) -> FakeWindowBuilder { w.title = title; return self }
-    public func setRect(_ rect: CGRect) -> FakeWindowBuilder { w.rect = rect; return self }
-    public func setPosition(_ pos: CGPoint) -> FakeWindowBuilder { w.rect = CGRect(origin: pos,
-    size: w.rect.size); return self }
-    public func setSize(_ size: CGSize) -> FakeWindowBuilder { w.rect.size = size; return self }
+    public func setFrame(_ frame: CGRect) -> FakeWindowBuilder { w.frame = frame; return self }
+    public func setPosition(_ pos: CGPoint) -> FakeWindowBuilder { w.frame = CGRect(origin: pos,
+    size: w.frame.size); return self }
+    public func setSize(_ size: CGSize) -> FakeWindowBuilder { w.frame.size = size; return self }
     public func setMinimized(_ isMinimized: Bool = true) -> FakeWindowBuilder {
         w.isMinimized = isMinimized
         return self
@@ -187,7 +187,7 @@ public class FakeWindow: TestObject {
         get { return try! element.attribute(.title)! }
         set { try! element.setAttribute(.title, value: newValue) }
     }
-    public var rect: CGRect {
+    public var frame: CGRect {
         get { return invert(try! element.attribute(.frame)!) }
         set { try! element.setAttribute(.frame, value: invert(newValue)) }
     }
@@ -217,7 +217,7 @@ public class FakeWindow: TestObject {
         element.companion = self
 
         title = "FakeWindow"
-        rect = CGRect(x: 300, y: 300, width: 600, height: 800)
+        frame = CGRect(x: 300, y: 300, width: 600, height: 800)
         isMinimized = false
         isFullscreen = false
     }

--- a/Sources/Window.swift
+++ b/Sources/Window.swift
@@ -104,7 +104,7 @@ protocol WindowDelegate: class {
 
     var frame: WriteableProperty<OfType<CGRect>>! { get }
     var position: Property<OfType<CGPoint>>! { get }
-    var size: WriteableProperty<OfType<CGSize>>! { get }
+    var size: SizeProperty! { get }
     var title: Property<OfType<String>>! { get }
     var isMinimized: WriteableProperty<OfType<Bool>>! { get }
     var isFullscreen: WriteableProperty<OfType<Bool>>! { get }
@@ -134,7 +134,7 @@ final class OSXWindowDelegate<
 
     var frame: WriteableProperty<OfType<CGRect>>!
     var position: Property<OfType<CGPoint>>!
-    var size: WriteableProperty<OfType<CGSize>>!
+    var size: SizeProperty!
     var title: Property<OfType<String>>!
     var isMinimized: WriteableProperty<OfType<Bool>>!
     var isFullscreen: WriteableProperty<OfType<Bool>>!

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -34,19 +34,21 @@ class StubWindowDelegate: WindowDelegate {
 
     var frame: WriteableProperty<OfType<CGRect>>!
     var position: Property<OfType<CGPoint>>!
-    var size: WriteableProperty<OfType<CGSize>>!
+    var size: SizeProperty!
     var title: Property<OfType<String>>!
     var isMinimized: WriteableProperty<OfType<Bool>>!
     var isFullscreen: WriteableProperty<OfType<Bool>>!
 
+    let frame_ = StubPropertyDelegate(value: CGRect.zero)
     let position_ = StubPropertyDelegate(value: CGPoint.zero)
     let size_ = StubPropertyDelegate(value: CGSize.zero)
 
     init() {
         let notifier = TestPropertyNotifier()
 
+        frame = WriteableProperty(frame_, notifier: notifier)
         position = WriteableProperty(position_, notifier: notifier)
-        size = WriteableProperty(size_, notifier: notifier)
+        size = SizeProperty(size_, notifier: notifier, frame: frame)
     }
 
     func equalTo(_ other: WindowDelegate) -> Bool { return self === other }

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -27,9 +27,9 @@ class FakeSpec: QuickSpec {
 
             it("builds with the requested properties") {
                 expect(fake.title).to(equal("I'm a test window"))
-                expect(fake.rect.origin).to(equal(CGPoint(x: 100, y: 100)))
+                expect(fake.frame.origin).to(equal(CGPoint(x: 100, y: 100)))
                 expect(fake.window.title.value).to(equal("I'm a test window"))
-                expect(fake.window.position.value).to(equal(CGPoint(x: 100, y: 100)))
+                expect(fake.window.frame.value.origin).to(equal(CGPoint(x: 100, y: 100)))
 
                 expect(fake.isMinimized).to(beFalse())
                 expect(fake.isFullscreen).to(beFalse())
@@ -37,10 +37,10 @@ class FakeSpec: QuickSpec {
 
             it("sees changes from Swindler") {
                 fake.window.frame.value.origin = CGPoint(x: 99, y: 100)
-                expect(fake.rect.origin).toEventually(equal(CGPoint(x: 99, y: 100)))
+                expect(fake.frame.origin).toEventually(equal(CGPoint(x: 99, y: 100)))
 
                 fake.window.size.value = CGSize(width: 1111, height: 2222)
-                expect(fake.rect.size).toEventually(equal(CGSize(width: 1111, height: 2222)))
+                expect(fake.frame.size).toEventually(equal(CGSize(width: 1111, height: 2222)))
 
                 fake.window.isMinimized.value = true
                 expect(fake.isMinimized).toEventually(beTrue())
@@ -55,10 +55,10 @@ class FakeSpec: QuickSpec {
                 fake.title = "My title changes"
                 expect(fake.window.title.value).toEventually(equal("My title changes"))
 
-                fake.rect.origin = CGPoint(x: 200, y: 200)
-                expect(fake.window.position.value).toEventually(equal(CGPoint(x: 200, y: 200)))
+                fake.frame.origin = CGPoint(x: 200, y: 200)
+                expect(fake.window.frame.value.origin).toEventually(equal(CGPoint(x: 200, y: 200)))
 
-                fake.rect.size = CGSize(width: 3333, height: 4444)
+                fake.frame.size = CGSize(width: 3333, height: 4444)
                 expect(fake.window.size.value).toEventually(equal(CGSize(width: 3333, height: 4444)))
 
                 fake.isMinimized = true

--- a/SwindlerTests/WindowSpec.swift
+++ b/SwindlerTests/WindowSpec.swift
@@ -321,6 +321,11 @@ class OSXWindowDelegateSpec: QuickSpec {
                         expect(event.external).to(beFalse())
                     }
                 }
+                it("immediately updates size") {
+                    if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
+                        expect(event.window.size.value) == event.window.frame.value.size
+                    }
+                }
             }
 
             context("and both position and size are changed") {
@@ -334,6 +339,31 @@ class OSXWindowDelegateSpec: QuickSpec {
                         expect(event.external).to(beFalse())
                     }
                 }
+                it("immediately updates size") {
+                    if let event = notifier.expectEvent(WindowFrameChangedEvent.self) {
+                        expect(event.window.size.value) == event.window.frame.value.size
+                    }
+                }
+            }
+        }
+
+        describe("frame and size sync") {
+            it("immediately updates size when frame is set") { () -> Promise<Void> in
+                return windowDelegate
+                    .frame
+                    .set(CGRect(x: 500, y: 500, width: 200, height: 200))
+                    .then { _ in
+                        expect(windowDelegate.size.value) == windowDelegate.frame.value.size
+                    }
+            }
+
+            it("immediately updates frame when size is set") { () -> Promise<Void> in
+                return windowDelegate
+                    .size
+                    .set(CGSize(width: 200, height: 200))
+                    .then { _ in
+                        expect(windowDelegate.frame.value.size) == windowDelegate.size.value
+                    }
             }
         }
 

--- a/SwindlerTests/WindowSpec.swift
+++ b/SwindlerTests/WindowSpec.swift
@@ -501,10 +501,10 @@ class WindowSpec: QuickSpec {
 
             func setWindowRect(_ rect: CGRect) {
                 windowDelegate.position_.value = rect.origin
-                windowDelegate.size_.value = rect.size
+                windowDelegate.frame_.value = rect
                 waitUntil { done in
                     when(fulfilled: windowDelegate.position.refresh(),
-                                    windowDelegate.size.refresh())
+                                    windowDelegate.frame.refresh())
                         .then { _ in done() }.always {}
                 }
             }


### PR DESCRIPTION
It turns out I couldn't do this with a delegate, like I mentioned in #48. The best way to keep these properties in sync was to remove (or disregard) the backing store of `size` altogether, which required subclassing `WriteableProperty`.

I'm happy with the result, but it makes me wonder if `PropertyDelegate` is still pulling its weight.