### PR TITLE
Use SPM instead of submodule for AXSwift

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "AXSwift"]
-	path = AXSwift
-	url = https://github.com/tmandry/AXSwift.git

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "AXSwift",
+        "repositoryURL": "https://github.com/tmandry/AXSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "dbf34341fd9a5892a5f8a646699c82308ae40c42",
+          "version": "0.3.1"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
@@ -12,7 +21,7 @@
       },
       {
         "package": "PromiseKit",
-        "repositoryURL": "https://github.com/mxcl/PromiseKit",
+        "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
           "revision": "aea48ea1855f5d82e2dffa6027afce3aab8f3dd7",

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(path: "./AXSwift"),
-        .package(url: "https://github.com/mxcl/PromiseKit", from: "6.13.3"),
+        .package(url: "https://github.com/tmandry/AXSwift.git", from: "0.3.0"),
+        .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.13.3"),
         .package(url: "https://github.com/Quick/Quick.git", from: "1.3.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "7.3.1"),
     ],

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -63,7 +63,10 @@ class TestUIElement: UIElementType, Hashable {
         TestUIElement.elementCount += 1
         id = TestUIElement.elementCount
     }
-    var hashValue: Int { return id }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
 
     func pid() throws -> pid_t { return processID }
     func attribute<T>(_ attr: Attribute) throws -> T? {


### PR DESCRIPTION
Fixes #71.