### PR TITLE
Clean up issues with FakeSwindler

### DIFF
--- a/Sources/AXSwiftProtocols.swift
+++ b/Sources/AXSwiftProtocols.swift
@@ -38,10 +38,6 @@ extension AXSwift.Observer: ObserverType {
 protocol ApplicationElementType: UIElementType {
     associatedtype UIElement: UIElementType
 
-    init?(forProcessID processID: pid_t)
-
-    static func all() -> [Self]
-
     // Until the Swift type system improves, I don't see a way around this.
     var toElement: UIElement { get }
 }

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -121,6 +121,15 @@ final class OSXApplicationDelegate<
         return windows.map({ $0 as WindowDelegate })
     }
 
+    static func initializeForTest(
+        _ axElement: ApplicationElement,
+        _ stateDelegate: StateDelegate,
+        _ notifier: EventNotifier
+    ) throws -> (OSXApplicationDelegate, Promise<OSXApplicationDelegate>) {
+        let appDelegate = try OSXApplicationDelegate(axElement, stateDelegate, notifier)
+        return (appDelegate, appDelegate.initialized.map { appDelegate })
+    }
+
     /// Initializes the object and returns it as a Promise that resolves once it's ready.
     static func initialize(
         axElement: ApplicationElement,
@@ -128,12 +137,12 @@ final class OSXApplicationDelegate<
         notifier: EventNotifier
     ) -> Promise<OSXApplicationDelegate> {
         return firstly { () -> Promise<OSXApplicationDelegate> in // capture thrown errors in promise chain
-            let appDelegate = try OSXApplicationDelegate(axElement, stateDelegate, notifier)
-            return appDelegate.initialized.map { appDelegate }
+            let (_, promise) = try initializeForTest(axElement, stateDelegate, notifier)
+            return promise
         }
     }
 
-    init(_ axElement: ApplicationElement,
+    private init(_ axElement: ApplicationElement,
          _ stateDelegate: StateDelegate,
          _ notifier: EventNotifier) throws {
         // TODO: filter out applications by activation policy

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -327,6 +327,7 @@ extension OSXApplicationDelegate {
         }
     }
 
+    // Also used by FakeSwindler.
     internal func addWindowElement(_ windowElement: UIElement) -> Promise<WinDelegate?> {
         return firstly {
             createWindowForElementIfNotExists(windowElement)

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -121,15 +121,6 @@ final class OSXApplicationDelegate<
         return windows.map({ $0 as WindowDelegate })
     }
 
-    static func initializeForTest(
-        _ axElement: ApplicationElement,
-        _ stateDelegate: StateDelegate,
-        _ notifier: EventNotifier
-    ) throws -> (OSXApplicationDelegate, Promise<OSXApplicationDelegate>) {
-        let appDelegate = try OSXApplicationDelegate(axElement, stateDelegate, notifier)
-        return (appDelegate, appDelegate.initialized.map { appDelegate })
-    }
-
     /// Initializes the object and returns it as a Promise that resolves once it's ready.
     static func initialize(
         axElement: ApplicationElement,
@@ -137,8 +128,8 @@ final class OSXApplicationDelegate<
         notifier: EventNotifier
     ) -> Promise<OSXApplicationDelegate> {
         return firstly { () -> Promise<OSXApplicationDelegate> in // capture thrown errors in promise chain
-            let (_, promise) = try initializeForTest(axElement, stateDelegate, notifier)
-            return promise
+            let appDelegate = try OSXApplicationDelegate(axElement, stateDelegate, notifier)
+            return appDelegate.initialized.map { appDelegate }
         }
     }
 

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -202,19 +202,19 @@ final class EmittingTestApplicationElement: TestApplicationElement {
 
     override func setAttribute(_ attribute: Attribute, value: Any) throws {
         try super.setAttribute(attribute, value: value)
-        let notification = { () -> AXNotification? in
+        let notifications = { () -> [AXNotification] in
             switch attribute {
             case .mainWindow:
-                return .mainWindowChanged
+                return [.mainWindowChanged, .focusedWindowChanged]
             case .focusedWindow:
-                return .focusedWindowChanged
+                return [.focusedWindowChanged]
             case .hidden:
-                return (value as? Bool == true) ? .applicationHidden : .applicationShown
+                return (value as? Bool == true) ? [.applicationHidden] : [.applicationShown]
             default:
-                return nil
+                return []
             }
         }()
-        if let notification = notification {
+        for notification in notifications {
             for observer in observers {
                 observer.unbox?.emit(notification, forElement: self)
             }

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -141,11 +141,11 @@ func ==(lhs: TestUIElement, rhs: TestUIElement) -> Bool {
     return lhs.id == rhs.id
 }
 
-class TestApplicationElementBase: TestUIElement {
+class TestApplicationElement: TestUIElement, ApplicationElementType {
     typealias UIElementType = TestUIElement
     var toElement: TestUIElement { return self }
 
-    init(processID: pid_t?, id: Int? = nil) {
+    init(processID: pid_t? = nil, id: Int? = nil) {
         super.init()
         if let id = id {
             self.id = id
@@ -192,13 +192,7 @@ class TestApplicationElementBase: TestUIElement {
     }
 }
 
-// ApplicationElementType requires static func all() -> [Self], which must be handled in each
-// (final) leaf class.
-final class TestApplicationElement: TestApplicationElementBase, ApplicationElementType {
-    init() { super.init(processID: nil) }
-}
-
-final class EmittingTestApplicationElement: TestApplicationElementBase, ApplicationElementType {
+final class EmittingTestApplicationElement: TestApplicationElement {
     init() {
         observers = []
         super.init(processID: EmittingTestApplicationElement.nextPID)
@@ -245,8 +239,8 @@ final class EmittingTestApplicationElement: TestApplicationElementBase, Applicat
 }
 
 class TestWindowElement: TestUIElement {
-    var app: TestApplicationElementBase
-    init(forApp app: TestApplicationElementBase) {
+    var app: TestApplicationElement
+    init(forApp app: TestApplicationElement) {
         self.app = app
         super.init()
         processID = app.processID
@@ -267,7 +261,7 @@ class TestWindowElement: TestUIElement {
             // Setting .main to false does nothing.
             guard value as! Bool == true else { return }
 
-            // Let TestApplicationElementBase.setAttribute do the heavy lifting, and return.
+            // Let TestApplicationElement.setAttribute do the heavy lifting, and return.
             try app.setAttribute(.mainWindow, value: self)
             return
         }
@@ -284,7 +278,7 @@ extension TestWindowElement: CustomDebugStringConvertible {
 }
 
 class EmittingTestWindowElement: TestWindowElement {
-    override init(forApp app: TestApplicationElementBase) {
+    override init(forApp app: TestApplicationElement) {
         observers = []
         super.init(forApp: app)
     }

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -196,14 +196,6 @@ class TestApplicationElementBase: TestUIElement {
 // (final) leaf class.
 final class TestApplicationElement: TestApplicationElementBase, ApplicationElementType {
     init() { super.init(processID: nil) }
-    init?(forProcessID processID: pid_t) {
-        guard let _ = TestApplicationElement.all().first(where: {$0.processID == processID}) else {
-            return nil
-        }
-        super.init(processID: processID)
-    }
-    static var allApps: [TestApplicationElement] = []
-    static func all() -> [TestApplicationElement] { return TestApplicationElement.allApps }
 }
 
 final class EmittingTestApplicationElement: TestApplicationElementBase, ApplicationElementType {
@@ -211,22 +203,8 @@ final class EmittingTestApplicationElement: TestApplicationElementBase, Applicat
         observers = []
         super.init(processID: EmittingTestApplicationElement.nextPID)
         EmittingTestApplicationElement.nextPID += 1
-        EmittingTestApplicationElement.allApps.append(self)
     }
     static var nextPID: pid_t = 1
-
-    init?(forProcessID processID: pid_t) {
-        observers = []
-        let apps = EmittingTestApplicationElement.all()
-        guard let other = apps.first(where: {$0.processID == processID}) else {
-            return nil
-        }
-        super.init(processID: processID, id: other.id)
-    }
-    static var allApps: [EmittingTestApplicationElement] = []
-    static func all() -> [EmittingTestApplicationElement] {
-        return EmittingTestApplicationElement.allApps
-    }
 
     override func setAttribute(_ attribute: Attribute, value: Any) throws {
         try super.setAttribute(attribute, value: value)
@@ -422,6 +400,15 @@ class FakeApplicationObserver: ApplicationObserverType {
 
     func makeApplicationFrontmost(_ pid: pid_t) throws {
         setFrontmost(pid)
+    }
+
+    typealias ApplicationElement = EmittingTestApplicationElement
+    var allApps: [ApplicationElement] = []
+    func allApplications() -> [EmittingTestApplicationElement] {
+        return allApps
+    }
+    func appElement(forProcessID processID: pid_t) -> EmittingTestApplicationElement? {
+        return allApps.first(where: {$0.processID == processID})
     }
 }
 

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -227,6 +227,13 @@ final class EmittingTestApplicationElement: TestApplicationElementBase, Applicat
         }
     }
 
+    func addWindow(_ window: EmittingTestWindowElement) {
+        // TODO update attrs[.window]
+        for observer in observers {
+            observer.unbox?.emit(.windowCreated, forElement: window)
+        }
+    }
+
     private var observers: [WeakBox<FakeObserver>]
 
     override func addObserver(_ observer: FakeObserver) {
@@ -310,6 +317,12 @@ class EmittingTestWindowElement: TestWindowElement {
         observers.append(WeakBox(observer))
     }
 
+    func destroy() {
+        for observer in observers {
+            observer.unbox?.emit(.uiElementDestroyed, forElement: self)
+        }
+    }
+
     // Useful hack to store companion objects (like FakeWindow).
     weak var companion: AnyObject?
 }
@@ -317,17 +330,12 @@ class EmittingTestWindowElement: TestWindowElement {
 class FakeObserver: ObserverType {
     typealias Context = FakeObserver
     typealias UIElement = TestUIElement
-    static var observers: [Context] = []
     var callback: Callback!
     var lock: NSLock = NSLock()
     var watchedElements: [TestUIElement: [AXNotification]] = [:]
 
-    //static var observers: [FakeObserverBase] = []
-
     required init(processID: pid_t, callback: @escaping Callback) throws {
         self.callback = callback
-        //try ObserverType.init(processID: processID, callback: callback)
-        FakeObserver.observers.append(self)
     }
 
     func addNotification(_ notification: AXNotification, forElement element: TestUIElement) throws {

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -127,10 +127,13 @@ public class FakeApplication {
         parent.appObserver.allApps.append(element)
         processId = element.processID
         isHidden = false
-        delegate = try! Delegate(element, parent.delegate, parent.delegate.notifier)
+        let (d, initialized) = try! Delegate.initializeForTest(element, parent.delegate, parent.delegate.notifier)
+        delegate = d
+        initialized.tap { _ in
+            parent.delegate.applicationsByPID[self.processId] = self.delegate
+        }.cauterize()
 
         element.companion = self
-        parent.appObserver.launch(processId)
     }
 
     public func createWindow() -> FakeWindowBuilder {

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -61,20 +61,20 @@ public struct FakeApplicationBuilder {
         app = FakeApplication(parent: parent)
     }
 
-    func setProcessId(_ pid: pid_t) -> FakeApplicationBuilder {
+    public func setProcessId(_ pid: pid_t) -> FakeApplicationBuilder {
         app.processId = pid
         return self
     }
-    func setBundleId(_ bundleId: String?) -> FakeApplicationBuilder {
+    public func setBundleId(_ bundleId: String?) -> FakeApplicationBuilder {
         app.bundleId = bundleId
         return self
     }
-    func setHidden(_ hidden: Bool) -> FakeApplicationBuilder {
+    public func setHidden(_ hidden: Bool) -> FakeApplicationBuilder {
         app.isHidden = hidden
         return self
     }
 
-    func build() -> Promise<FakeApplication> {
+    public func build() -> Promise<FakeApplication> {
         return app.parent.delegate.addAppElement(app.element).map { delegate in
             app.delegate = delegate
             return app

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -75,12 +75,8 @@ public struct FakeApplicationBuilder {
     }
 
     func build() -> Promise<FakeApplication> {
-        // TODO do event firing
-        return FakeApplication.Delegate.initialize(
-            axElement: app.element, stateDelegate: app.parent.delegate, notifier: app.parent.delegate.notifier
-        ).map { delegate in
+        return app.parent.delegate.addAppElement(app.element).map { delegate in
             app.delegate = delegate
-            app.parent.delegate.applicationsByPID[app.processId] = delegate
             return app
         }
     }

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -17,7 +17,7 @@ fileprivate typealias AppElement = EmittingTestApplicationElement
 
 public class FakeState {
     fileprivate typealias Delegate =
-        OSXStateDelegate<TestUIElement, AppElement, FakeObserver>
+        OSXStateDelegate<TestUIElement, AppElement, FakeObserver, FakeApplicationObserver>
 
     public static func initialize(screens: [FakeScreen] = [FakeScreen()]) -> Promise<FakeState> {
         let appObserver = FakeApplicationObserver()
@@ -34,7 +34,7 @@ public class FakeState {
     public var frontmostApplication: FakeApplication? {
         get {
             guard let pid = appObserver.frontmostApplicationPID else { return nil }
-            guard let elem = try! AppElement.all().first(where: { try $0.pid() == pid }) else {
+            guard let elem = appObserver.appElement(forProcessID: pid) else {
                 return nil
             }
             return Optional(elem.companion as! FakeApplication)
@@ -124,6 +124,7 @@ public class FakeApplication {
     public init(parent: FakeState) {
         self.parent = parent
         element = AppElement()
+        parent.appObserver.allApps.append(element)
         processId = element.processID
         isHidden = false
         delegate = try! Delegate(element, parent.delegate, parent.delegate.notifier)

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -78,7 +78,10 @@ struct Log {
         } else {
             output = string
         }
-        print(output, to: &stderrStream)
+        // stderr seems to get thrown away by `swift test`, so we print to stdout
+        // for now.
+        // print(output, to: &stderrStream)
+        print(output)
     }
 
 }

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -205,7 +205,7 @@ final class OSXStateDelegate<
     typealias WinDelegate = OSXWindowDelegate<UIElement, ApplicationElement, Observer>
     typealias AppDelegate = OSXApplicationDelegate<UIElement, ApplicationElement, Observer>
 
-    fileprivate var applicationsByPID: [pid_t: AppDelegate] = [:]
+    var applicationsByPID: [pid_t: AppDelegate] = [:]
     var notifier: EventNotifier
 
     fileprivate var appObserver: ApplicationObserver

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -10,13 +10,13 @@ import PromiseKit
 class OSXDriverSpec: QuickSpec {
     override func spec() {
 
-        beforeEach { TestApplicationElement.allApps = [] }
         beforeEach { FakeObserver.observers = [] }
 
         // Set up a state with a single application containing a single window.
         var appElement: TestApplicationElement!
         var windowElement: TestWindowElement!
         var observer: FakeObserver!
+        var appObserver: StubApplicationObserver!
         var state: State!
         beforeEach {
             appElement = TestApplicationElement()
@@ -24,12 +24,13 @@ class OSXDriverSpec: QuickSpec {
             windowElement.attrs[.position] = CGPoint(x: 5, y: 5)
             appElement.attrs[.windows] = [windowElement as TestUIElement]
             appElement.attrs[.mainWindow] = windowElement
-            TestApplicationElement.allApps = [appElement]
+            appObserver = StubApplicationObserver()
+            appObserver.allApps = [appElement]
 
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
             state = State(delegate: OSXStateDelegate<
-                TestUIElement, TestApplicationElement, FakeObserver
-            >(appObserver: StubApplicationObserver(), screens: screenDel))
+                TestUIElement, TestApplicationElement, FakeObserver, StubApplicationObserver
+            >(appObserver: appObserver, screens: screenDel))
             observer = FakeObserver.observers.first!
             observer.emit(.windowCreated, forElement: windowElement)
             expect(state.knownWindows.count).toEventually(equal(1))

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -10,29 +10,25 @@ import PromiseKit
 class OSXDriverSpec: QuickSpec {
     override func spec() {
 
-        beforeEach { FakeObserver.observers = [] }
-
         // Set up a state with a single application containing a single window.
-        var appElement: TestApplicationElement!
-        var windowElement: TestWindowElement!
-        var observer: FakeObserver!
-        var appObserver: StubApplicationObserver!
+        var appElement: EmittingTestApplicationElement!
+        var windowElement: EmittingTestWindowElement!
+        var appObserver: FakeApplicationObserver!
         var state: State!
         beforeEach {
-            appElement = TestApplicationElement()
-            windowElement = TestWindowElement(forApp: appElement)
+            appElement = EmittingTestApplicationElement()
+            windowElement = EmittingTestWindowElement(forApp: appElement)
             windowElement.attrs[.position] = CGPoint(x: 5, y: 5)
             appElement.attrs[.windows] = [windowElement as TestUIElement]
             appElement.attrs[.mainWindow] = windowElement
-            appObserver = StubApplicationObserver()
+            appObserver = FakeApplicationObserver()
             appObserver.allApps = [appElement]
 
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
             state = State(delegate: OSXStateDelegate<
-                TestUIElement, TestApplicationElement, FakeObserver, StubApplicationObserver
+                TestUIElement, EmittingTestApplicationElement, FakeObserver, FakeApplicationObserver
             >(appObserver: appObserver, screens: screenDel))
-            observer = FakeObserver.observers.first!
-            observer.emit(.windowCreated, forElement: windowElement)
+            appElement.addWindow(windowElement)
             expect(state.knownWindows.count).toEventually(equal(1))
         }
 
@@ -56,8 +52,8 @@ class OSXDriverSpec: QuickSpec {
                 state.on { (_: WindowCreatedEvent) in
                     callbacks += 1
                 }
-                let window = TestWindowElement(forApp: appElement)
-                observer.emit(.windowCreated, forElement: window)
+                let window = EmittingTestWindowElement(forApp: appElement)
+                appElement.addWindow(window)
                 expect(state.knownWindows).toEventually(haveCount(2))
                 expect(callbacks).to(equal(1), description: "callback should be called once")
             }
@@ -71,13 +67,13 @@ class OSXDriverSpec: QuickSpec {
                 state.on { (_: WindowDestroyedEvent) in
                     callbacks += 1
                 }
-                observer.emit(.uiElementDestroyed, forElement: windowElement)
+                windowElement.destroy()
                 expect(callbacks)
                     .toEventually(equal(1), description: "callback should be called once")
             }
 
             it("removes the window from knownWindows") {
-                observer.emit(.uiElementDestroyed, forElement: windowElement)
+                windowElement.destroy()
                 expect(state.knownWindows).toEventually(haveCount(0))
             }
 
@@ -90,8 +86,7 @@ class OSXDriverSpec: QuickSpec {
                 state.on { (_: WindowFrameChangedEvent) in
                     callbacks += 1
                 }
-                windowElement.attrs[.position] = CGPoint(x: 100, y: 100)
-                observer.emit(.moved, forElement: windowElement)
+                try! windowElement.setAttribute(.position, value: CGPoint(x: 100, y: 100))
                 expect(callbacks)
                     .toEventually(equal(1), description: "callback should be called once")
             }
@@ -105,8 +100,7 @@ class OSXDriverSpec: QuickSpec {
                 state.on { (_: WindowFrameChangedEvent) in
                     callbacks2 += 1
                 }
-                windowElement.attrs[.position] = CGPoint(x: 100, y: 100)
-                observer.emit(.moved, forElement: windowElement)
+                try! windowElement.setAttribute(.position, value: CGPoint(x: 100, y: 100))
                 expect(callbacks1)
                     .toEventually(equal(1), description: "callback1 should be called once")
                 expect(callbacks2)

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -135,6 +135,15 @@ class FakeSpec: QuickSpec {
                 fakeApp.application.mainWindow.value = fakeWindow2.window
                 expect(fakeState.state.runningApplications[0].mainWindow.value).toEventually(equal(fakeWindow2.window))
             }
+
+            it("updates focusedWindow when mainWindow changes") {
+                fakeApp.mainWindow = fakeWindow1
+                expect(fakeApp.application.mainWindow.value).toEventually(equal(fakeWindow1.window))
+                expect(fakeApp.application.focusedWindow.value).toEventually(equal(fakeWindow1.window))
+                fakeApp.mainWindow = fakeWindow2
+                expect(fakeApp.application.mainWindow.value).toEventually(equal(fakeWindow2.window))
+                expect(fakeApp.application.focusedWindow.value).toEventually(equal(fakeWindow2.window))
+            }
         }
 
         describe("FakeState") {

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -139,6 +139,19 @@ class FakeSpec: QuickSpec {
                 expect(fakeApp.application.mainWindow.value).toEventually(equal(fakeWindow2.window))
                 expect(fakeApp.application.focusedWindow.value).toEventually(equal(fakeWindow2.window))
             }
+
+            it("emits events when new windows are created") { () -> Promise<()> in
+                var events: [WindowCreatedEvent] = []
+                fakeState.state.on { (event: WindowCreatedEvent) in
+                    events.append(event)
+                }
+                return FakeWindowBuilder(parent: fakeApp)
+                    .build()
+                    .done { win in
+                        expect(events).to(haveCount(1))
+                        expect(events.first!.window).to(equal(win.window))
+                    }
+            }
         }
 
         describe("FakeState") {
@@ -197,6 +210,19 @@ class FakeSpec: QuickSpec {
                     fakeApp.isHidden = true
                     expect(fakeApp.isHidden).to(beTrue())
                     expect(app.isHidden.value).toEventually(beTrue())
+                }
+
+                it("emits events when new applications are created") { () -> Promise<()> in
+                    var events: [ApplicationLaunchedEvent] = []
+                    fakeState.state.on { (event: ApplicationLaunchedEvent) in
+                        events.append(event)
+                    }
+                    return FakeApplicationBuilder(parent: fakeState)
+                        .build()
+                        .done { app in
+                            expect(events).to(haveCount(1))
+                            expect(events.first!.application).to(equal(app.application))
+                        }
                 }
             }
         }

--- a/SwindlerTests/StateSpec.swift
+++ b/SwindlerTests/StateSpec.swift
@@ -22,8 +22,6 @@ class StubApplicationObserver: ApplicationObserverType {
 class OSXStateDelegateSpec: QuickSpec {
     override func spec() {
 
-        beforeEach { FakeObserver.observers = [] }
-
         func initialize()
         -> OSXStateDelegate<TestUIElement, TestApplicationElement, TestObserver, StubApplicationObserver> {
             initialize(StubApplicationObserver())

--- a/SwindlerTests/WindowSpec.swift
+++ b/SwindlerTests/WindowSpec.swift
@@ -19,7 +19,6 @@ class OSXWindowDelegateInitializeSpec: QuickSpec {
 
         var windowElement: TestWindowElement!
         beforeEach {
-            TestApplicationElement.allApps = []
             windowElement = TestWindowElement(forApp: TestApplicationElement())
         }
 
@@ -152,14 +151,12 @@ class OSXWindowDelegateNotificationSpec: QuickSpec {
                 appElement.windows.append(windowElement)
             }
 
-            var observer: AdversaryObserver!
             func initialize() -> Promise<WinDelegate> {
                 return AppDelegate
                     .initialize(axElement: appElement,
                                 stateDelegate: StubStateDelegate(),
                                 notifier: TestNotifier())
                     .map { appDelegate -> WinDelegate in
-                        observer = appDelegate.observer
                         guard let winDelegate = appDelegate.knownWindows.first
                                                 as! WinDelegate? else {
                             throw TestError("Window delegate was not initialized by application "

--- a/SwindlerTests/support/AdversaryFakes.swift
+++ b/SwindlerTests/support/AdversaryFakes.swift
@@ -44,7 +44,7 @@ final class AdversaryObserver: FakeObserver {
 }
 
 /// Allows defining adversarial actions when an attribute is read.
-final class AdversaryApplicationElement: TestApplicationElementBase, ApplicationElementType {
+final class AdversaryApplicationElement: TestApplicationElement {
     static var allApps: [AdversaryApplicationElement] = []
     static func all() -> [AdversaryApplicationElement] {
       return AdversaryApplicationElement.allApps


### PR DESCRIPTION
Removed a lot of global state from the early days of the test fixtures, made the interface more uniform, and fixed some bugs.