### PR TITLE
Basic spaces support

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -380,7 +380,7 @@ extension OSXApplicationDelegate {
             // checks inexplicably return false. (This has been observed for Finder.) In this case
             // we will never see a new window for this element. Asynchronously check the element
             // role to handle this case.
-            //checkIfWindowPropertyElementIsActuallyApplication(element, property: property)
+            checkIfWindowPropertyElementIsActuallyApplication(element, property: property)
         }
     }
 

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -369,7 +369,6 @@ extension OSXApplicationDelegate {
         } else {
             // We don't know about the element that has been passed. Wait until the window is
             // initialized.
-            //newWindowHandler.performAfterWindowCreatedForElement(element) { property.refresh() }
             createWindowForElementIfNotExists(element)
                 .done { _ in property.refresh() }
                 .recover { err in

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -157,7 +157,7 @@ public struct ScreenLayoutChangedEvent: EventType {
 public struct SpaceWillChangeEvent: EventType {
     public let external: Bool
     /// For each screen, a unique integer identifying the visible space.
-    public let id: [Int]
+    public let ids: [Int]
 }
 
 /// The space has changed, and the list of known windows is up to date.
@@ -169,5 +169,5 @@ public struct SpaceWillChangeEvent: EventType {
 public struct SpaceDidChangeEvent: EventType {
     public let external: Bool
     /// For each screen, a unique integer identifying the visible space.
-    public let id: [Int]
+    public let ids: [Int]
 }

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -152,3 +152,8 @@ public struct ScreenLayoutChangedEvent: EventType {
     public let changedScreens: [Screen]
     public let unchangedScreens: [Screen]
 }
+
+public struct SpaceChangedEvent: EventType {
+    public let external: Bool
+    public let id: Int
+}

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -153,7 +153,14 @@ public struct ScreenLayoutChangedEvent: EventType {
     public let unchangedScreens: [Screen]
 }
 
-public struct SpaceChangedEvent: EventType {
+/// The space has changed, but we have not yet updated the list of known windows.
+public struct SpaceWillChangeEvent: EventType {
+    public let external: Bool
+    public let id: Int
+}
+
+/// The space has changed, and the list of known windows is up to date.
+public struct SpaceDidChangeEvent: EventType {
     public let external: Bool
     public let id: Int
 }

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -156,11 +156,11 @@ public struct ScreenLayoutChangedEvent: EventType {
 /// The space has changed, but we have not yet updated the list of known windows.
 public struct SpaceWillChangeEvent: EventType {
     public let external: Bool
-    public let id: Int
+    public let id: [Int]
 }
 
 /// The space has changed, and the list of known windows is up to date.
 public struct SpaceDidChangeEvent: EventType {
     public let external: Bool
-    public let id: Int
+    public let id: [Int]
 }

--- a/Sources/Events.swift
+++ b/Sources/Events.swift
@@ -156,11 +156,18 @@ public struct ScreenLayoutChangedEvent: EventType {
 /// The space has changed, but we have not yet updated the list of known windows.
 public struct SpaceWillChangeEvent: EventType {
     public let external: Bool
+    /// For each screen, a unique integer identifying the visible space.
     public let id: [Int]
 }
 
 /// The space has changed, and the list of known windows is up to date.
+///
+/// Note that this event may not correspond 1:1 with SpaceWillChangeEvent.
+/// In particular, if the space changes again before the list of known windows
+/// can be updated, SpaceWillChangeEvent will fire twice and this event will
+/// fire only once.
 public struct SpaceDidChangeEvent: EventType {
     public let external: Bool
+    /// For each screen, a unique integer identifying the visible space.
     public let id: [Int]
 }

--- a/Sources/FakeAXSwift.swift
+++ b/Sources/FakeAXSwift.swift
@@ -400,6 +400,10 @@ class FakeApplicationObserver: ApplicationObserverType {
         terminateHandlers.append(handler)
     }
 
+    func onSpaceChanged(_ handler: @escaping (Int) -> Void) {
+        // TODO
+    }
+
     func makeApplicationFrontmost(_ pid: pid_t) throws {
         setFrontmost(pid)
     }

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -20,11 +20,12 @@ public class FakeState {
         OSXStateDelegate<TestUIElement, AppElement, FakeObserver, FakeApplicationObserver>
 
     public static func initialize(screens: [FakeScreen] = [FakeScreen()]) -> Promise<FakeState> {
+        let notifier = EventNotifier()
         let appObserver = FakeApplicationObserver()
         let screens = FakeSystemScreenDelegate(screens: screens.map{ $0.delegate })
-        let spaces = FakeSpaceObserver()
+        let spaces = FakeSpaceObserver(notifier)
         return firstly {
-            Delegate.initialize(appObserver, screens, spaces)
+            Delegate.initialize(notifier, appObserver, screens, spaces)
         }.map { delegate in
             FakeState(delegate, appObserver, spaces)
         }

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -22,8 +22,9 @@ public class FakeState {
     public static func initialize(screens: [FakeScreen] = [FakeScreen()]) -> Promise<FakeState> {
         let appObserver = FakeApplicationObserver()
         let screens = FakeSystemScreenDelegate(screens: screens.map{ $0.delegate })
+        let spaces = FakeSpaceObserver()
         return firstly {
-            Delegate.initialize(appObserver: appObserver, screens: screens)
+            Delegate.initialize(appObserver, screens, spaces)
         }.map { delegate in
             FakeState(delegate, appObserver)
         }

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -45,7 +45,7 @@ public class FakeState {
         }
     }
 
-    public var currentSpaceId: Int {
+    public var currentSpaceId: [Int] {
         get { spaceObserver.spaceId }
         set { spaceObserver.spaceId = newValue }
     }

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -46,10 +46,6 @@ public class FakeState {
         }
     }
 
-    public var currentSpaceId: [Int] {
-        get { spaceObserver.spaceId }
-        set { spaceObserver.spaceId = newValue }
-    }
     public var newSpaceId: Int {
         spaceObserver.newSpaceId
     }
@@ -267,6 +263,10 @@ public class FakeScreen {
         get {
             return Screen(delegate: delegate)
         }
+    }
+    public var spaceId: Int? {
+        get { delegate.spaceId }
+        set { delegate.spaceId = newValue }
     }
 
     public init(frame: CGRect, applicationFrame: CGRect) {

--- a/Sources/FakeSwindler.swift
+++ b/Sources/FakeSwindler.swift
@@ -26,7 +26,7 @@ public class FakeState {
         return firstly {
             Delegate.initialize(appObserver, screens, spaces)
         }.map { delegate in
-            FakeState(delegate, appObserver)
+            FakeState(delegate, appObserver, spaces)
         }
     }
 
@@ -45,13 +45,27 @@ public class FakeState {
         }
     }
 
+    public var currentSpaceId: Int {
+        get { spaceObserver.spaceId }
+        set { spaceObserver.spaceId = newValue }
+    }
+    public var newSpaceId: Int {
+        spaceObserver.newSpaceId
+    }
+
     fileprivate var delegate: Delegate
     var appObserver: FakeApplicationObserver
+    var spaceObserver: FakeSpaceObserver
 
-    private init(_ delegate: Delegate, _ appObserver: FakeApplicationObserver) {
+    private init(
+        _ delegate: Delegate,
+        _ appObserver: FakeApplicationObserver,
+        _ spaces: FakeSpaceObserver
+    ) {
         self.state = State(delegate: delegate)
         self.delegate = delegate
         self.appObserver = appObserver
+        self.spaceObserver = spaces
     }
 }
 

--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -95,7 +95,7 @@ struct Log {
             }
             // stderr seems to get thrown away by `swift test`, so we print to stdout
             // for now.
-            print(output, to: &stderrStream)
+            // print(output, to: &stderrStream)
             print(output)
         }
     }

--- a/Sources/Screen.swift
+++ b/Sources/Screen.swift
@@ -19,6 +19,9 @@ public final class Screen: Equatable, CustomDebugStringConvertible {
     /// The frame defining the screen boundaries in global coordinates, excluding the menu bar and
     /// dock.
     public var applicationFrame: CGRect { return delegate.applicationFrame }
+
+    /// An integer uniquely representing the current space on this screen.
+    public var spaceId: Int { delegate.spaceId ?? 0 }
 }
 public func ==(lhs: Screen, rhs: Screen) -> Bool {
     return lhs.delegate.equalTo(rhs.delegate)
@@ -57,6 +60,7 @@ protocol ScreenDelegate: AnyObject, CustomDebugStringConvertible {
     var frame: CGRect { get }
     var applicationFrame: CGRect { get }
     var native: NSScreen? { get }
+    var spaceId: Int? { get set }
 
     func equalTo(_ other: ScreenDelegate) -> Bool
 }
@@ -95,6 +99,7 @@ class FakeSystemScreenDelegate: SystemScreenDelegate {
 final class FakeScreenDelegate: ScreenDelegate {
     let frame: CGRect
     let applicationFrame: CGRect
+    var spaceId: Int?
 
     init(frame: CGRect, applicationFrame: CGRect) {
         self.frame = frame
@@ -234,6 +239,7 @@ private let kNSScreenNumber = "NSScreenNumber"
 
 final class OSXScreenDelegate<NSScreenT: NSScreenType>: ScreenDelegate {
     fileprivate let nsScreen: NSScreenT
+    var spaceId: Int?
 
     // This ID is guaranteed to stay the same for any given display. NSScreen equality checks can
     // fail if the display switches graphics cards.

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -1,0 +1,76 @@
+import Cocoa
+
+class SpaceObserver: NSObject, NSWindowDelegate {
+    var windows: [Int: NSWindow] = [:]
+
+    override init() {
+        super.init()
+        makeWindow()
+    }
+
+    /// Create an invisible window for tracking the current space.
+    ///
+    /// This helps us identify the space when we return to it in the future.
+    /// It also helps us detect when a space is closed and merged into another.
+    /// Without the window events we wouldn't have a way of noticing when this
+    /// happened.
+    @discardableResult
+    private func makeWindow() -> Int {
+        //win = NSWindow(contentViewController: NSViewController(nibName: nil, bundle: nil))
+        // Size must be non-zero to receive occlusion state events.
+        let rect = /*NSRect.zero */NSRect(x: 0, y: 0, width: 1, height: 1)
+        let win = NSWindow(contentRect: rect, styleMask: .borderless/*[.titled, .resizable, .miniaturizable]*/, backing: .buffered, defer: false)
+        win.delegate = self
+        //win.title = "test"
+        win.isReleasedWhenClosed = false
+        win.ignoresMouseEvents = true
+        win.hasShadow = false
+        win.animationBehavior = .none
+        win.backgroundColor = NSColor.clear
+        win.level = .floating
+        win.collectionBehavior = [.transient, .ignoresCycle, .fullScreenAuxiliary]
+        if #available(macOS 10.11, *) {
+            win.collectionBehavior.update(with: .fullScreenDisallowsTiling)
+        }
+        win.makeKeyAndOrderFront(nil)
+        log.debug("new window windowNumber=\(win.windowNumber)")
+        windows[win.windowNumber] = win
+        return win.windowNumber
+    }
+
+    func windowDidChangeScreen(_ notification: Notification) {
+        let win = notification.object as! NSWindow
+        log.debug("window \(win.windowNumber) changed screen; active=\(win.isOnActiveSpace)")
+    }
+
+    func windowDidChangeOcclusionState(_ notification: Notification) {
+        let win = notification.object as! NSWindow
+        log.debug("window \(win.windowNumber) occstchanged; occVis=\(win.occlusionState.contains(NSWindow.OcclusionState.visible)), vis=\(win.isVisible), activeSpace=\(win.isOnActiveSpace)")
+        let visible = (NSWindow.windowNumbers(options: []) ?? []) as! [Int]
+        log.debug("visible=\(visible)")
+        // TODO: Use this event to detect space merges.
+    }
+
+    func onSpaceChanged(_ handler: @escaping (Int) -> Void) {
+        let sharedWorkspace = NSWorkspace.shared
+        let notificationCenter = sharedWorkspace.notificationCenter
+        notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: sharedWorkspace,
+            queue: nil
+        ) { _ in self.spaceChanged(handler) }
+        spaceChanged(handler)
+    }
+
+    private func spaceChanged(_ handler: @escaping (Int) -> Void) {
+        // TODO: One per screen
+        log.notice("space changed")
+        //log.notice("active=\(win.isOnActiveSpace)")
+        var visible = (NSWindow.windowNumbers(options: []) ?? []) as! [Int]
+        log.notice("visible=\(visible)")
+        if visible.isEmpty {
+            visible = [makeWindow()]
+        }
+        handler(visible.first!)
+    }
+}

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -64,10 +64,9 @@ class SpaceObserver: NSObject, NSWindowDelegate {
 
     private func spaceChanged(_ handler: @escaping (Int) -> Void) {
         // TODO: One per screen
-        log.notice("space changed")
         //log.notice("active=\(win.isOnActiveSpace)")
         var visible = (NSWindow.windowNumbers(options: []) ?? []) as! [Int]
-        log.notice("visible=\(visible)")
+        log.debug("visible=\(visible)")
         if visible.isEmpty {
             visible = [makeWindow()]
         }

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -19,7 +19,7 @@ class FakeSpaceObserver: SpaceObserver {
     }
     var newSpaceId: Int = 2
     func emitSpaceWillChangeEvent() {
-        notifier?.notify(SpaceWillChangeEvent(external: true, id: spaceId))
+        notifier?.notify(SpaceWillChangeEvent(external: true, ids: spaceId))
     }
 }
 
@@ -88,7 +88,7 @@ class OSXSpaceObserver: NSObject, NSWindowDelegate, SpaceObserver {
                 visiblePerScreen.append(makeWindow(screens[idx]))
             }
         }
-        notifier?.notify(SpaceWillChangeEvent(external: true, id: visiblePerScreen))
+        notifier?.notify(SpaceWillChangeEvent(external: true, ids: visiblePerScreen))
     }
 }
 

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -21,6 +21,7 @@ class FakeSpaceObserver: SpaceObserver {
     }
     var newSpaceId: Int = 2
     func onSpaceChanged(_ handler: @escaping (Int) -> Void) {
+        handler(spaceId)
         handlers.append(handler)
     }
 }

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -1,7 +1,32 @@
 import Cocoa
 
-class SpaceObserver: NSObject, NSWindowDelegate {
-    var windows: [Int: NSWindow] = [:]
+protocol SpaceObserver {
+    /// Registers a handler to be called on a space change.
+    ///
+    /// The handler is called with a unique integer identifying the space. The
+    /// handler is called immediately upon registration with the current space
+    /// id.
+    func onSpaceChanged(_ handler: @escaping (Int) -> Void)
+}
+
+class FakeSpaceObserver: SpaceObserver {
+    var handlers: [(Int) -> Void] = []
+    var spaceId: Int = 1 {
+        didSet {
+            newSpaceId = max(newSpaceId, spaceId + 1)
+            for handler in handlers {
+                handler(spaceId)
+            }
+        }
+    }
+    var newSpaceId: Int = 2
+    func onSpaceChanged(_ handler: @escaping (Int) -> Void) {
+        handlers.append(handler)
+    }
+}
+
+class OSXSpaceObserver: NSObject, NSWindowDelegate, SpaceObserver {
+    private var windows: [Int: NSWindow] = [:]
 
     override init() {
         super.init()

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -1,14 +1,6 @@
 import Cocoa
 
-protocol SpaceObserver {
-    /// Emits a SpaceWillChangeEvent on the notifier this observer was
-    /// constructed with.
-    ///
-    /// Used during initialization.
-    func emitSpaceWillChangeEvent()
-}
-
-class OSXSpaceObserver: NSObject, NSWindowDelegate, SpaceObserver {
+class OSXSpaceObserver: NSObject, NSWindowDelegate {
     private var trackers: [Int: SpaceTracker] = [:]
     private weak var ssd: SystemScreenDelegate?
     private var sst: SystemSpaceTracker
@@ -41,6 +33,10 @@ class OSXSpaceObserver: NSObject, NSWindowDelegate, SpaceObserver {
         return win.id
     }
 
+    /// Emits a SpaceWillChangeEvent on the notifier this observer was
+    /// constructed with.
+    ///
+    /// Used during initialization.
     func emitSpaceWillChangeEvent() {
         guard let ssd = ssd else { return }
         let visible = sst.visibleIds()

--- a/Sources/Space.swift
+++ b/Sources/Space.swift
@@ -86,8 +86,7 @@ class OSXSpaceObserver: NSObject, NSWindowDelegate, SpaceObserver {
 
         var visiblePerScreen: [Int] = []
         for (idx, visible) in visibleByScreen.enumerated() {
-            // TODO: Break ties deterministically (and test)
-            if let id = visible.first {
+            if let id = visible.min() {
                 visiblePerScreen.append(id)
             } else {
                 visiblePerScreen.append(makeWindow(screens[idx]))

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -216,7 +216,7 @@ final class OSXStateDelegate<
     var notifier: EventNotifier
 
     fileprivate var appObserver: ApplicationObserver
-    fileprivate var spaceObserver: SpaceObserver
+    fileprivate var spaceObserver: OSXSpaceObserver
 
     // For convenience/readability.
     fileprivate var applications: Dictionary<pid_t, AppDelegate>.Values {
@@ -239,11 +239,11 @@ final class OSXStateDelegate<
     // TODO: retry instead of ignoring an app/window when timeouts are encountered during
     // initialization?
 
-    static func initialize<Screens: SystemScreenDelegate, Spaces: SpaceObserver>(
+    static func initialize<Screens: SystemScreenDelegate>(
         _ notifier: EventNotifier,
         _ appObserver: ApplicationObserver,
         _ screens: Screens,
-        _ spaces: Spaces
+        _ spaces: OSXSpaceObserver
     ) -> Promise<OSXStateDelegate> {
         return firstly { () -> Promise<OSXStateDelegate> in
             let delegate = OSXStateDelegate(notifier, appObserver, screens, spaces)
@@ -252,11 +252,11 @@ final class OSXStateDelegate<
     }
 
     // TODO make private
-    init<Screens: SystemScreenDelegate, Spaces: SpaceObserver>(
+    init<Screens: SystemScreenDelegate>(
         _ notifier: EventNotifier,
         _ appObserver: ApplicationObserver,
         _ screens: Screens,
-        _ spaces: Spaces
+        _ spaces: OSXSpaceObserver
     ) {
         log.debug("Initializing Swindler")
 

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -49,8 +49,8 @@ public final class State {
     }
 
     /// A unique integer representing the current space.
-    public var space: Int {
-        delegate.space
+    public var currentSpaceId: Int {
+        delegate.currentSpaceId
     }
 
     /// Calls `handler` when the specified `Event` occurs.
@@ -69,7 +69,7 @@ protocol StateDelegate: AnyObject {
     var frontmostApplication: WriteableProperty<OfOptionalType<Application>>! { get }
     var knownWindows: [WindowDelegate] { get }
     var systemScreens: SystemScreenDelegate { get }
-    var space: Int { get }
+    var currentSpaceId: Int { get }
 
     var notifier: EventNotifier { get }
 }
@@ -234,7 +234,7 @@ final class OSXStateDelegate<
     var systemScreens: SystemScreenDelegate
 
     var spaceId: Int!
-    var space: Int { spaceId }
+    var currentSpaceId: Int { spaceId }
 
     fileprivate var initialized: Promise<Void>!
 

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -48,8 +48,8 @@ public final class State {
         return delegate.systemScreens.screens.map {Screen(delegate: $0)}
     }
 
-    /// A unique integer representing the current space.
-    public var currentSpaceId: Int {
+    /// A unique integer representing the current space for every screen.
+    public var currentSpaceId: [Int] {
         delegate.currentSpaceId
     }
 
@@ -69,7 +69,7 @@ protocol StateDelegate: AnyObject {
     var frontmostApplication: WriteableProperty<OfOptionalType<Application>>! { get }
     var knownWindows: [WindowDelegate] { get }
     var systemScreens: SystemScreenDelegate { get }
-    var currentSpaceId: Int { get }
+    var currentSpaceId: [Int] { get }
 
     var notifier: EventNotifier { get }
 }
@@ -233,8 +233,8 @@ final class OSXStateDelegate<
     }
     var systemScreens: SystemScreenDelegate
 
-    var spaceId: Int!
-    var currentSpaceId: Int { spaceId }
+    var spaceId: [Int]!
+    var currentSpaceId: [Int] { spaceId }
 
     fileprivate var initialized: Promise<Void>!
 

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -290,14 +290,14 @@ final class OSXStateDelegate<
         appObserver.onApplicationTerminated(onApplicationTerminate)
 
         spaceObserver.onSpaceChanged() { id in
-            log.notice("Space changed: \(id)")
+            log.info("Space changed: \(id)")
             self.spaceId = id
-            self.notifier.notify(SpaceChangedEvent(external: true, id: id))
+            self.notifier.notify(SpaceWillChangeEvent(external: true, id: id))
 
             let updateWindows = self.applications.map { app in app.onSpaceChanged() }
             when(resolved: updateWindows).done { _ in
                 log.notice("Known windows updated")
-                // TODO: event
+                self.notifier.notify(SpaceDidChangeEvent(external: true, id: id))
             }.recover { error in
                 log.error("Couldn't update window list after space change: \(error)")
             }

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -4,6 +4,7 @@ import PromiseKit
 
 /// Initializes a new Swindler state and returns it in a Promise.
 public func initialize() -> Promise<State> {
+    let ssd = OSXSystemScreenDelegate()
     return OSXStateDelegate<
         AXSwift.UIElement,
         AXSwift.Application,
@@ -11,8 +12,8 @@ public func initialize() -> Promise<State> {
         ApplicationObserver
     >.initialize(
         ApplicationObserver(),
-        OSXSystemScreenDelegate(),
-        OSXSpaceObserver()
+        ssd,
+        OSXSpaceObserver(ssd, OSXSystemSpaceTracker())
     ).map { delegate in
        State(delegate: delegate)
     }

--- a/SwindlerTests/ApplicationSpec.swift
+++ b/SwindlerTests/ApplicationSpec.swift
@@ -607,7 +607,7 @@ class OSXApplicationDelegateSpec: QuickSpec {
 
                 context("and the passed application element doesn't equal our stored application "
                       + "element") {
-                    // Because shit happens. Finder does this.
+                    // Finder does this.
                     it("becomes nil") {
                         let otherAppElement = TestUIElement()
                         otherAppElement.processID = appElement.processID

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -8,7 +8,7 @@ class StubStateDelegate: StateDelegate {
     var knownWindows: [WindowDelegate] = []
     var systemScreens: SystemScreenDelegate { return fakeScreens }
     var notifier: EventNotifier = EventNotifier()
-    var currentSpaceId: Int = 0
+    var currentSpaceId: [Int] = [0]
 
     var fakeScreens: FakeSystemScreenDelegate = FakeSystemScreenDelegate(screens: [])
 }

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -8,7 +8,7 @@ class StubStateDelegate: StateDelegate {
     var knownWindows: [WindowDelegate] = []
     var systemScreens: SystemScreenDelegate { return fakeScreens }
     var notifier: EventNotifier = EventNotifier()
-    var space: Int = 0
+    var currentSpaceId: Int = 0
 
     var fakeScreens: FakeSystemScreenDelegate = FakeSystemScreenDelegate(screens: [])
 }

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -8,6 +8,7 @@ class StubStateDelegate: StateDelegate {
     var knownWindows: [WindowDelegate] = []
     var systemScreens: SystemScreenDelegate { return fakeScreens }
     var notifier: EventNotifier = EventNotifier()
+    var space: Int = 0
 
     var fakeScreens: FakeSystemScreenDelegate = FakeSystemScreenDelegate(screens: [])
 }

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -66,6 +66,8 @@ class StubScreenDelegate: ScreenDelegate {
 
     var debugDescription: String { return "StubScreenDelegate" }
 
+    var native: NSScreen? { nil }
+
     func equalTo(_ other: ScreenDelegate) -> Bool { return self === other }
 }
 

--- a/SwindlerTests/DelegateStubs.swift
+++ b/SwindlerTests/DelegateStubs.swift
@@ -57,6 +57,7 @@ class StubWindowDelegate: WindowDelegate {
 class StubScreenDelegate: ScreenDelegate {
     var frame: CGRect = CGRect.zero
     var applicationFrame: CGRect = CGRect.zero
+    var spaceId: Int?
 
     init() {}
     init(frame: CGRect) {

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -26,7 +26,7 @@ class OSXDriverSpec: QuickSpec {
 
             let notifier = EventNotifier()
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
-            let spaces = FakeSpaceObserver(notifier)
+            let spaces = OSXSpaceObserver(notifier, screenDel, FakeSystemSpaceTracker())
             state = State(delegate: OSXStateDelegate<
                 TestUIElement, EmittingTestApplicationElement, FakeObserver, FakeApplicationObserver
             >(notifier, appObserver, screenDel, spaces))

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -24,11 +24,12 @@ class OSXDriverSpec: QuickSpec {
             appObserver = FakeApplicationObserver()
             appObserver.allApps = [appElement]
 
+            let notifier = EventNotifier()
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
-            let spaces = FakeSpaceObserver()
+            let spaces = FakeSpaceObserver(notifier)
             state = State(delegate: OSXStateDelegate<
                 TestUIElement, EmittingTestApplicationElement, FakeObserver, FakeApplicationObserver
-            >(appObserver, screenDel, spaces))
+            >(notifier, appObserver, screenDel, spaces))
             appElement.addWindow(windowElement)
             expect(state.knownWindows.count).toEventually(equal(1))
         }

--- a/SwindlerTests/DriverSpec.swift
+++ b/SwindlerTests/DriverSpec.swift
@@ -25,9 +25,10 @@ class OSXDriverSpec: QuickSpec {
             appObserver.allApps = [appElement]
 
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
+            let spaces = FakeSpaceObserver()
             state = State(delegate: OSXStateDelegate<
                 TestUIElement, EmittingTestApplicationElement, FakeObserver, FakeApplicationObserver
-            >(appObserver: appObserver, screens: screenDel))
+            >(appObserver, screenDel, spaces))
             appElement.addWindow(windowElement)
             expect(state.knownWindows.count).toEventually(equal(1))
         }

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -187,9 +187,9 @@ class FakeSpec: QuickSpec {
                     expect(fakeState.state.frontmostApplication.value).toEventually(
                         equal(fakeApp2.application))
                     let newSpace = fakeState.newSpaceId
-                    expect(fakeState.currentSpaceId) != newSpace
-                    fakeState.currentSpaceId = newSpace
-                    expect(fakeState.state.currentSpaceId).toEventually(equal(newSpace))
+                    expect(fakeState.currentSpaceId) != [newSpace]
+                    fakeState.currentSpaceId = [newSpace]
+                    expect(fakeState.state.currentSpaceId).toEventually(equal([newSpace]))
                 }
             }
 

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -157,11 +157,13 @@ class FakeSpec: QuickSpec {
         describe("FakeState") {
             context("") {
                 var fakeState: FakeState!
+                var fakeScreen: FakeScreen!
                 var fakeApp1: FakeApplication!
                 var fakeApp2: FakeApplication!
                 beforeEach {
                     waitUntil { done in
-                        FakeState.initialize()
+                        fakeScreen = FakeScreen()
+                        FakeState.initialize(screens: [fakeScreen])
                             .map { fakeState = $0 }
                             .then { FakeApplicationBuilder(parent: fakeState).build() }
                             .map { fakeApp1 = $0 }
@@ -187,9 +189,9 @@ class FakeSpec: QuickSpec {
                     expect(fakeState.state.frontmostApplication.value).toEventually(
                         equal(fakeApp2.application))
                     let newSpace = fakeState.newSpaceId
-                    expect(fakeState.currentSpaceId) != [newSpace]
-                    fakeState.currentSpaceId = [newSpace]
-                    expect(fakeState.state.currentSpaceId).toEventually(equal([newSpace]))
+                    expect(fakeScreen.spaceId) != newSpace
+                    fakeScreen.spaceId = newSpace
+                    expect(fakeState.state.screens.first!.spaceId).toEventually(equal(newSpace))
                 }
             }
 

--- a/SwindlerTests/FakeSpec.swift
+++ b/SwindlerTests/FakeSpec.swift
@@ -186,6 +186,10 @@ class FakeSpec: QuickSpec {
                     fakeState.frontmostApplication = fakeApp2
                     expect(fakeState.state.frontmostApplication.value).toEventually(
                         equal(fakeApp2.application))
+                    let newSpace = fakeState.newSpaceId
+                    expect(fakeState.currentSpaceId) != newSpace
+                    fakeState.currentSpaceId = newSpace
+                    expect(fakeState.state.currentSpaceId).toEventually(equal(newSpace))
                 }
             }
 

--- a/SwindlerTests/SpaceSpec.swift
+++ b/SwindlerTests/SpaceSpec.swift
@@ -1,0 +1,64 @@
+import Cocoa
+import Quick
+import Nimble
+
+@testable import Swindler
+
+class StubSystemSpaceTracker: SystemSpaceTracker {
+    init() {}
+
+    var spaceChangeHandler: Optional<() -> ()> = nil
+    func onSpaceChanged(_ handler: @escaping () -> ()) {
+        spaceChangeHandler = handler
+    }
+
+    var trackersMade: [StubSpaceTracker] = []
+    func makeTracker(_ screen: ScreenDelegate) -> SpaceTracker {
+        let tracker = StubSpaceTracker(screen, id: trackersMade.count + 1)
+        trackersMade.append(tracker)
+        visible.append(tracker.id)
+        return tracker
+    }
+
+    var visible: [Int] = []
+    func visibleIds() -> [Int] { visible }
+}
+
+class StubSpaceTracker: SpaceTracker {
+    var screen: ScreenDelegate?
+    var id: Int
+    init(_ screen: ScreenDelegate?, id: Int) {
+        self.screen = screen
+        self.id = id
+    }
+    func screen(_ ssd: SystemScreenDelegate) -> ScreenDelegate? { screen }
+}
+
+class OSXSpaceObserverSpec: QuickSpec {
+    override func spec() {
+        var screen1: OSXScreenDelegate<StubNSScreen>!
+        var screen2: OSXScreenDelegate<StubNSScreen>!
+        var ssd: FakeSystemScreenDelegate!
+        beforeEach {
+            screen1 = OSXScreenDelegate(nsScreen: StubNSScreen(1))
+            screen2 = OSXScreenDelegate(nsScreen: StubNSScreen(2))
+            ssd = FakeSystemScreenDelegate(screens: [screen1, screen2])
+        }
+
+        describe("spaces") {
+            it("work") {
+                let sst = StubSystemSpaceTracker()
+                let observer = OSXSpaceObserver(ssd, sst)
+                var visible: [Int]?
+                observer.onSpaceChanged { ids in visible = ids }
+                expect(sst.trackersMade).to(haveCount(2))
+                expect(visible).to(contain(1, 2))
+                sst.visible = [1]
+                sst.spaceChangeHandler?()
+                expect(sst.trackersMade).to(haveCount(3))
+                expect(visible).to(contain(1, 3))
+                expect(sst.trackersMade.last?.screen?.equalTo(screen2)) == true
+            }
+        }
+    }
+}

--- a/SwindlerTests/SpaceSpec.swift
+++ b/SwindlerTests/SpaceSpec.swift
@@ -36,6 +36,7 @@ class StubSpaceTracker: SpaceTracker {
 
 class OSXSpaceObserverSpec: QuickSpec {
     override func spec() {
+        var notifier: EventNotifier!
         var screen1: OSXScreenDelegate<StubNSScreen>!
         var screen2: OSXScreenDelegate<StubNSScreen>!
         var ssd: FakeSystemScreenDelegate!
@@ -43,12 +44,14 @@ class OSXSpaceObserverSpec: QuickSpec {
         var observer: OSXSpaceObserver!
         var visibleIds: [Int]?
         beforeEach {
+            notifier = EventNotifier()
             screen1 = OSXScreenDelegate(nsScreen: StubNSScreen(1))
             screen2 = OSXScreenDelegate(nsScreen: StubNSScreen(2))
             ssd = FakeSystemScreenDelegate(screens: [screen1, screen2])
             sst = StubSystemSpaceTracker()
-            observer = OSXSpaceObserver(ssd, sst)
-            observer.onSpaceChanged { ids in visibleIds = ids }
+            observer = OSXSpaceObserver(notifier, ssd, sst)
+            notifier.on { (event: SpaceWillChangeEvent) in visibleIds = event.id }
+            observer.emitSpaceWillChangeEvent()
         }
 
         describe("spaces") {

--- a/SwindlerTests/SpaceSpec.swift
+++ b/SwindlerTests/SpaceSpec.swift
@@ -4,43 +4,13 @@ import Nimble
 
 @testable import Swindler
 
-class StubSystemSpaceTracker: SystemSpaceTracker {
-    init() {}
-
-    var spaceChangeHandler: Optional<() -> ()> = nil
-    func onSpaceChanged(_ handler: @escaping () -> ()) {
-        spaceChangeHandler = handler
-    }
-
-    var trackersMade: [StubSpaceTracker] = []
-    func makeTracker(_ screen: ScreenDelegate) -> SpaceTracker {
-        let tracker = StubSpaceTracker(screen, id: trackersMade.count + 1)
-        trackersMade.append(tracker)
-        visible.append(tracker.id)
-        return tracker
-    }
-
-    var visible: [Int] = []
-    func visibleIds() -> [Int] { visible }
-}
-
-class StubSpaceTracker: SpaceTracker {
-    var screen: ScreenDelegate?
-    var id: Int
-    init(_ screen: ScreenDelegate?, id: Int) {
-        self.screen = screen
-        self.id = id
-    }
-    func screen(_ ssd: SystemScreenDelegate) -> ScreenDelegate? { screen }
-}
-
 class OSXSpaceObserverSpec: QuickSpec {
     override func spec() {
         var notifier: EventNotifier!
         var screen1: OSXScreenDelegate<StubNSScreen>!
         var screen2: OSXScreenDelegate<StubNSScreen>!
         var ssd: FakeSystemScreenDelegate!
-        var sst: StubSystemSpaceTracker!
+        var sst: FakeSystemSpaceTracker!
         var observer: OSXSpaceObserver!
         var visibleIds: [Int]?
         beforeEach {
@@ -48,7 +18,7 @@ class OSXSpaceObserverSpec: QuickSpec {
             screen1 = OSXScreenDelegate(nsScreen: StubNSScreen(1))
             screen2 = OSXScreenDelegate(nsScreen: StubNSScreen(2))
             ssd = FakeSystemScreenDelegate(screens: [screen1, screen2])
-            sst = StubSystemSpaceTracker()
+            sst = FakeSystemSpaceTracker()
             observer = OSXSpaceObserver(notifier, ssd, sst)
             notifier.on { (event: SpaceWillChangeEvent) in visibleIds = event.ids }
             observer.emitSpaceWillChangeEvent()

--- a/SwindlerTests/SpaceSpec.swift
+++ b/SwindlerTests/SpaceSpec.swift
@@ -50,7 +50,7 @@ class OSXSpaceObserverSpec: QuickSpec {
             ssd = FakeSystemScreenDelegate(screens: [screen1, screen2])
             sst = StubSystemSpaceTracker()
             observer = OSXSpaceObserver(notifier, ssd, sst)
-            notifier.on { (event: SpaceWillChangeEvent) in visibleIds = event.id }
+            notifier.on { (event: SpaceWillChangeEvent) in visibleIds = event.ids }
             observer.emitSpaceWillChangeEvent()
         }
 

--- a/SwindlerTests/StateSpec.swift
+++ b/SwindlerTests/StateSpec.swift
@@ -31,9 +31,10 @@ class OSXStateDelegateSpec: QuickSpec {
             _ appObserver: AppObserver
         ) -> OSXStateDelegate<TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver> {
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
+            let spaces = FakeSpaceObserver()
             let stateDel = OSXStateDelegate<
                 TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver
-            >(appObserver: appObserver, screens: screenDel)
+            >(appObserver, screenDel, spaces)
             waitUntil { done in
                 stateDel.frontmostApplication.initialized.done { done() }.cauterize()
             }
@@ -67,11 +68,9 @@ class OSXStateDelegateSpec: QuickSpec {
             {
                 let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
                 let observer = StubApplicationObserver()
+                let spaces = FakeSpaceObserver()
                 observer.allApps = apps
-                return OSXStateDelegate(
-                    appObserver: observer,
-                    screens: screenDel
-                )
+                return OSXStateDelegate(observer, screenDel, spaces)
             }
 
             it("observes all applications") {

--- a/SwindlerTests/StateSpec.swift
+++ b/SwindlerTests/StateSpec.swift
@@ -32,7 +32,7 @@ class OSXStateDelegateSpec: QuickSpec {
         ) -> OSXStateDelegate<TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver> {
             let notifier = EventNotifier()
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
-            let spaces = FakeSpaceObserver(notifier)
+            let spaces = OSXSpaceObserver(notifier, screenDel, FakeSystemSpaceTracker())
             let stateDel = OSXStateDelegate<
                 TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver
             >(notifier, appObserver, screenDel, spaces)
@@ -70,7 +70,7 @@ class OSXStateDelegateSpec: QuickSpec {
                 let notifier = EventNotifier()
                 let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
                 let observer = StubApplicationObserver()
-                let spaces = FakeSpaceObserver(notifier)
+                let spaces = OSXSpaceObserver(notifier, screenDel, FakeSystemSpaceTracker())
                 observer.allApps = apps
                 return OSXStateDelegate(notifier, observer, screenDel, spaces)
             }

--- a/SwindlerTests/StateSpec.swift
+++ b/SwindlerTests/StateSpec.swift
@@ -30,11 +30,12 @@ class OSXStateDelegateSpec: QuickSpec {
         func initialize<AppObserver: ApplicationObserverType>(
             _ appObserver: AppObserver
         ) -> OSXStateDelegate<TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver> {
+            let notifier = EventNotifier()
             let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
-            let spaces = FakeSpaceObserver()
+            let spaces = FakeSpaceObserver(notifier)
             let stateDel = OSXStateDelegate<
                 TestUIElement, AppObserver.ApplicationElement, TestObserver, AppObserver
-            >(appObserver, screenDel, spaces)
+            >(notifier, appObserver, screenDel, spaces)
             waitUntil { done in
                 stateDel.frontmostApplication.initialized.done { done() }.cauterize()
             }
@@ -66,11 +67,12 @@ class OSXStateDelegateSpec: QuickSpec {
             )
                 -> OSXStateDelegate<TestUIElement, TestApplicationElement, Obs, StubApplicationObserver>
             {
+                let notifier = EventNotifier()
                 let screenDel = FakeSystemScreenDelegate(screens: [FakeScreen().delegate])
                 let observer = StubApplicationObserver()
-                let spaces = FakeSpaceObserver()
+                let spaces = FakeSpaceObserver(notifier)
                 observer.allApps = apps
-                return OSXStateDelegate(observer, screenDel, spaces)
+                return OSXStateDelegate(notifier, observer, screenDel, spaces)
             }
 
             it("observes all applications") {


### PR DESCRIPTION
This adds basic support for spaces, using a unique integer ID to identify each space.

There are two space change events for before and after updating the set of known windows, so applications
can prioritize responsiveness if they don't need full information.

An invisible window is created on each space to track it. Note that this makes it possible to track
when spaces have been merged, but this is not yet supported.
